### PR TITLE
Fixed require, object iteration and range iteration snippets.

### DIFF
--- a/snippets/coffeescript.json
+++ b/snippets/coffeescript.json
@@ -46,7 +46,7 @@
       "prefix": "foro",
       "body": [
         "for ${1:key}, ${2:value} of ${3:object}",
-        "\t${3:# body...}"
+        "\t${4:# body...}"
       ]
     },
     "forinby": {
@@ -54,7 +54,7 @@
       "prefix": "forr",
       "body": [
         "for ${1:name} in [${2:start}..${3:finish}] by ${4:step}",
-        "\t${3:# body...}"
+        "\t${5:# body...}"
       ]
     },
     "function": {

--- a/snippets/coffeescript.json
+++ b/snippets/coffeescript.json
@@ -98,7 +98,7 @@
       "description": "Require statement",
       "prefix": "req",
       "body": [
-        "${fs} = require '${fs}"
+        "${fs} = require '${fs}'"
       ]
     },
     "switch": {


### PR DESCRIPTION
Require snippet was missing ending quote.
Object and range iterations had two times the number "3" as a focus-symbol argument.